### PR TITLE
[FEAT/Exception/#3] Global Exception 구현

### DIFF
--- a/src/main/java/com/trim/exception/advice/ExceptionAdvice.java
+++ b/src/main/java/com/trim/exception/advice/ExceptionAdvice.java
@@ -1,16 +1,124 @@
 package com.trim.exception.advice;
 
+import com.trim.exception.payload.code.ErrorStatus;
+import com.trim.exception.payload.code.Reason;
+import com.trim.exception.payload.dto.ApiResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+    private static final String CONSTRAINT_VIOLATION_EXCEPTION_ERROR_MESSAGE = "ConstraintViolationException 추출 도중 에러 발생";
 
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(CONSTRAINT_VIOLATION_EXCEPTION_ERROR_MESSAGE));
 
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
 
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage,
+                            (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
+                ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        Reason errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, Reason reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(reason.getCode(), reason.getMessage(), null);
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status,
+                                                                WebRequest request, String errorPoint) {
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+                errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers,
+                                                               ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+                errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+                null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
 }

--- a/src/main/java/com/trim/exception/advice/ExceptionAdvice.java
+++ b/src/main/java/com/trim/exception/advice/ExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.trim.exception.advice;
 
+import com.trim.exception.object.general.GeneralException;
 import com.trim.exception.payload.code.ErrorStatus;
 import com.trim.exception.payload.code.Reason;
 import com.trim.exception.payload.dto.ApiResponseDto;

--- a/src/main/java/com/trim/exception/advice/ExceptionAdvice.java
+++ b/src/main/java/com/trim/exception/advice/ExceptionAdvice.java
@@ -1,0 +1,16 @@
+package com.trim.exception.advice;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+
+
+}

--- a/src/main/java/com/trim/exception/object/general/GeneralException.java
+++ b/src/main/java/com/trim/exception/object/general/GeneralException.java
@@ -1,0 +1,21 @@
+package com.trim.exception.object.general;
+
+import com.trim.exception.payload.code.BaseCode;
+import com.trim.exception.payload.code.Reason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+    private BaseCode code;
+
+    public Reason getErrorReason(){
+        return this.code.getReason();
+    }
+
+    public Reason getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+    
+}

--- a/src/main/java/com/trim/exception/payload/code/BaseCode.java
+++ b/src/main/java/com/trim/exception/payload/code/BaseCode.java
@@ -1,0 +1,7 @@
+package com.trim.exception.payload.code;
+
+public interface BaseCode {
+    Reason getReason();
+
+    Reason getReasonHttpStatus();
+}

--- a/src/main/java/com/trim/exception/payload/code/ErrorStatus.java
+++ b/src/main/java/com/trim/exception/payload/code/ErrorStatus.java
@@ -1,0 +1,42 @@
+package com.trim.exception.payload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseCode{
+    // general error
+    _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
+    _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
+    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/trim/exception/payload/code/ErrorStatus.java
+++ b/src/main/java/com/trim/exception/payload/code/ErrorStatus.java
@@ -9,6 +9,9 @@ import static org.springframework.http.HttpStatus.*;
 @Getter
 @AllArgsConstructor
 public enum ErrorStatus implements BaseCode{
+    //server error
+    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 관리자에게 문의 바랍니다."),
+
     // general error
     _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
     _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),

--- a/src/main/java/com/trim/exception/payload/code/Reason.java
+++ b/src/main/java/com/trim/exception/payload/code/Reason.java
@@ -1,0 +1,19 @@
+package com.trim.exception.payload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.util.HashMap;
+
+@Getter
+@Builder
+public class Reason {
+
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final Integer code;
+    private final String message;
+    private final HashMap<String, String> result;
+
+}

--- a/src/main/java/com/trim/exception/payload/code/SuccessStatus.java
+++ b/src/main/java/com/trim/exception/payload/code/SuccessStatus.java
@@ -1,0 +1,36 @@
+package com.trim.exception.payload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    _SUCCESS(OK, 2000, "성공");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+                .code(code)
+                .message(message)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+                .httpStatus(httpStatus)
+                .code(code)
+                .message(message)
+                .isSuccess(true)
+                .build();
+    }
+}

--- a/src/main/java/com/trim/exception/payload/dto/ApiResponseDto.java
+++ b/src/main/java/com/trim/exception/payload/dto/ApiResponseDto.java
@@ -17,7 +17,7 @@ public class ApiResponseDto<T> {
     private T result;
 
     public static <T> ApiResponseDto onSuccess(T result){
-        return new ApiResponseDto(true, 2000, SuccessStatus._SUCCESS.getMessage(), result);
+        return new ApiResponseDto(true, SuccessStatus._SUCCESS.getCode(), SuccessStatus._SUCCESS.getMessage(), result);
     }
 
     public static <T> ApiResponseDto<T> of(BaseCode code, T result){

--- a/src/main/java/com/trim/exception/payload/dto/ApiResponseDto.java
+++ b/src/main/java/com/trim/exception/payload/dto/ApiResponseDto.java
@@ -1,0 +1,31 @@
+package com.trim.exception.payload.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.trim.exception.payload.code.BaseCode;
+import com.trim.exception.payload.code.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder
+public class ApiResponseDto<T> {
+
+    private final Boolean isSuccess;
+    private final Integer code;
+    private final String message;
+    private T result;
+
+    public static <T> ApiResponseDto onSuccess(T result){
+        return new ApiResponseDto(true, 2000, SuccessStatus._SUCCESS.getMessage(), result);
+    }
+
+    public static <T> ApiResponseDto<T> of(BaseCode code, T result){
+        return new ApiResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReason().getMessage(), result);
+    }
+
+    public static <T> ApiResponseDto<T> onFailure(Integer code, String message, T data){
+        return new ApiResponseDto<>(false, code, message, data);
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
Global Exception 에 필요한 기본 클래스들을 구현했습니다.

## 📝 작업 내용
- BaseCode
- Reason
- ErrorStatus
- SuccessStatus
- ApiResponseDto
- ExceptionAdvice
- GeneralException

## 동작 확인

## 💬 리뷰 요구사항(선택)

## 질문
### 1. ApiResponseDto
1.1 ApiResponseDto
```
 public static <T> ApiResponseDto onSuccess(T result){
        return new ApiResponseDto(true, 2000, SuccessStatus._SUCCESS.getMessage(), result);
    }
```
ApiResponseDto의 code 인자 부분을 2000으로 명시하여 SuccessStatus._SUCCESS.getCode()를 사용하지 않은 이유가 있나요?

1.2
```
public static <T> ApiResponseDto<T> of(BaseCode code, T result){
        return new ApiResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReason().getMessage(), result);
    }
```
of 메서드의 필요성에 대해 의문이 있습니다.
BaseCode 구현체인 SuccessStatus의 내부 Enum 요소는 1개인데,
isSuccess를 true로 리턴하는 of메서드는  SuccessStatus를 리턴하는 onSuccess와의 어떤 차이점이 있나요?

 추가로,  BaseCode에 getCode() 를 구현하지 않고 code.getReasonHttpStatus().getCode() 를 사용하는 이유는 무엇인가요??

## 코멘트
 패키지 구조는 상대적으로 더 직관적인 Waggle-server 프로젝트 구조를 따랐습니다.
내용은 완전히 동일하지만 최대한 이해하면서 진행하느라 시간이 조금 걸렸네요..

그리고 확실히 이런 방식으로 전역 예외를 구현하면 관리하기 정말 편할 것 같다는 생각이 들었습니다. 나중에 제 프로젝트에도 적용하고 싶네요 ㅎㅎ 

구현은 가장 기본적이라고 생각되는 부분만 개발했는데, 제가 놓친 부분이 있다면 추가 구현하도록 하겠습니다 !





